### PR TITLE
Pin react 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "next": "14.2.3",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "nodemailer": "^6.9.10"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- pin `react`/`react-dom` to `18.2.0`

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*
- `npm run lint` *(fails: `next` not found because dependencies are missing)*

------
https://chatgpt.com/codex/tasks/task_e_687829b89d908332a7841665f7ed8b80