### PR TITLE
Add placeholder pages

### DIFF
--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const AboutPage = () => {
+  return (
+    <main className="pt-20">
+      <div className="bg-whisper py-16">
+        <div className="container mx-auto max-w-7xl px-4">
+          <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">About Us</h1>
+          <p className="text-center text-lg text-gray-600 mt-4 max-w-3xl mx-auto">
+            Learn more about our company and mission.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default AboutPage;

--- a/src/pages/join.tsx
+++ b/src/pages/join.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const JoinPage = () => {
+  return (
+    <main className="pt-20">
+      <div className="bg-whisper py-16">
+        <div className="container mx-auto max-w-7xl px-4">
+          <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Join Us</h1>
+          <p className="text-center text-lg text-gray-600 mt-4 max-w-3xl mx-auto">
+            Sign up to get the latest updates and opportunities.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default JoinPage;

--- a/src/pages/learn.tsx
+++ b/src/pages/learn.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const LearnPage = () => {
+  return (
+    <main className="pt-20">
+      <div className="bg-whisper py-16">
+        <div className="container mx-auto max-w-7xl px-4">
+          <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Learn</h1>
+          <p className="text-center text-lg text-gray-600 mt-4 max-w-3xl mx-auto">
+            Discover resources and articles to boost your knowledge.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default LearnPage;

--- a/src/pages/support.tsx
+++ b/src/pages/support.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const SupportPage = () => {
+  return (
+    <main className="pt-20">
+      <div className="bg-whisper py-16">
+        <div className="container mx-auto max-w-7xl px-4">
+          <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Support Center</h1>
+          <p className="text-center text-lg text-gray-600 mt-4 max-w-3xl mx-auto">
+            How can we assist you? This page is under construction.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default SupportPage;


### PR DESCRIPTION
## Summary
- add placeholder `about`, `join`, `learn` and `support` pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68782a8bb31c8332aaa10fb2ebe47dd8