### PR TITLE
Add prop interfaces to components

### DIFF
--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import Link from 'next/link';
 
-const Benefits = () => {
+interface BenefitsProps {}
+
+const Benefits = ({}: BenefitsProps) => {
   return (
     <section className="py-20 bg-off-white">
       <div className="container mx-auto max-w-7xl px-4">

--- a/src/components/CTA.tsx
+++ b/src/components/CTA.tsx
@@ -2,7 +2,8 @@
 import React from 'react';
 import Link from 'next/link';
 
-const CTA = () => {
+interface CTAProps {}
+const CTA = ({}: CTAProps) => {
   return (
     <section className="py-20 bg-deep-blue text-white">
       <div className="container mx-auto max-w-7xl px-4 text-center">

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,7 +1,13 @@
 // components/Contact.jsx
 import React, { useState } from 'react';
 
-const ContactMethod = ({ icon, title, text }) => {
+interface ContactMethodProps {
+  icon: React.ReactNode;
+  title: string;
+  text: React.ReactNode;
+}
+
+const ContactMethod = ({ icon, title, text }: ContactMethodProps) => {
   return (
     <div className="text-center mb-8 md:mb-0">
       <div className="w-14 h-14 bg-perfume bg-opacity-20 rounded-full flex items-center justify-center mx-auto mb-4">
@@ -13,7 +19,9 @@ const ContactMethod = ({ icon, title, text }) => {
   );
 };
 
-const Contact = () => {
+interface ContactProps {}
+
+const Contact = ({}: ContactProps) => {
   const [formData, setFormData] = useState({
     name: '',
     email: '',
@@ -22,7 +30,9 @@ const Contact = () => {
   });
   const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle');
 
-  const handleChange = (e) => {
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
     const { name, value } = e.target;
     setFormData(prevState => ({
       ...prevState,

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -1,7 +1,13 @@
 // components/FAQ.jsx
 import React, { useState } from 'react';
 
-const FAQItem = ({ question, answer, isOpen, toggleOpen }) => {
+interface FAQItemProps {
+  question: string;
+  answer: string;
+  isOpen: boolean;
+  toggleOpen: () => void;
+}
+const FAQItem = ({ question, answer, isOpen, toggleOpen }: FAQItemProps) => {
   return (
     <div className="mb-4 border border-light-purple border-opacity-20 rounded-lg overflow-hidden">
       <button
@@ -32,7 +38,9 @@ const FAQItem = ({ question, answer, isOpen, toggleOpen }) => {
   );
 };
 
-const FAQ = () => {
+interface FAQProps {}
+
+const FAQ = ({}: FAQProps) => {
   const [openItem, setOpenItem] = useState(0);
 
   const faqItems = [

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,7 +2,8 @@
 import React from 'react';
 import Link from 'next/link';
 
-const Footer = () => {
+interface FooterProps {}
+const Footer = ({}: FooterProps) => {
   return (
     <footer className="bg-off-white py-10 border-t border-gray-100">
       <div className="container mx-auto max-w-7xl px-4">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import Link from 'next/link';
 
-const Hero = () => {
+interface HeroProps {}
+const Hero = ({}: HeroProps) => {
   return (
     <section className="bg-off-white pt-20 pb-20 ">
       <div className="px-12">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,7 +2,9 @@ import React, { useState } from 'react';
 import Link from 'next/link';
 import Full from '../assets/images/New.png';
 
-const Navbar = () => {
+interface NavbarProps {}
+
+const Navbar = ({}: NavbarProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -1,7 +1,14 @@
 // components/Portfolio.jsx
 import React, { useState } from 'react';
 
-const ProjectCard = ({ title, category, description, image, tags }) => {
+interface ProjectCardProps {
+  title: string;
+  category: string;
+  description: string;
+  image?: string;
+  tags: string[];
+}
+const ProjectCard = ({ title, category, description, image, tags }: ProjectCardProps) => {
   return (
     <div className="bg-white rounded-lg overflow-hidden shadow-md hover:shadow-lg transition-all duration-300">
       <div className="h-56 bg-light-purple bg-opacity-20 relative">
@@ -34,7 +41,9 @@ const ProjectCard = ({ title, category, description, image, tags }) => {
   );
 };
 
-const Portfolio = () => {
+interface PortfolioProps {}
+
+const Portfolio = ({}: PortfolioProps) => {
   const [filter, setFilter] = useState('all');
   
   const projects = [

--- a/src/components/Process.tsx
+++ b/src/components/Process.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import Link from 'next/link';
 
-const ProcessStep = ({ number, title, description }) => {
+interface ProcessStepProps {
+  number: string;
+  title: string;
+  description: string;
+}
+const ProcessStep = ({ number, title, description }: ProcessStepProps) => {
   return (
     <div className="text-center p-6 bg-white rounded-lg shadow-sm hover:shadow-md transition-all duration-300">
       <div className="w-16 h-16 bg-gradient-to-r from-primary-purple to-deep-blue text-white rounded-full flex items-center justify-center mx-auto mb-5 font-bold text-xl">
@@ -13,7 +18,9 @@ const ProcessStep = ({ number, title, description }) => {
   );
 };
 
-const Process = () => {
+interface ProcessProps {}
+
+const Process = ({}: ProcessProps) => {
   return (
     <section id="process" className="py-20 bg-off-white">
       <div className="container mx-auto max-w-7xl px-4">

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 
-const ServiceCard = ({ title, description, icon }) => {
+interface ServiceCardProps {
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+}
+const ServiceCard = ({ title, description, icon }: ServiceCardProps) => {
   return (
     <div className="bg-white p-8 rounded-lg text-center transform transition-transform hover:-translate-y-2 hover:shadow-xl">
       <div className="w-16 h-16 bg-light-purple bg-opacity-20 rounded-full flex items-center justify-center mx-auto mb-6">
@@ -12,7 +17,9 @@ const ServiceCard = ({ title, description, icon }) => {
   );
 };
 
-const Services = () => {
+interface ServicesProps {}
+
+const Services = ({}: ServicesProps) => {
   return (
     <section id="services" className="py-20 bg-white">
       <div className="container-custom">

--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -1,7 +1,20 @@
 // components/Team.jsx
 import React from 'react';
 
-const TeamMember = ({ name, role, bio, image, socialLinks }) => {
+interface SocialLink {
+  platform: string;
+  url: string;
+  icon: React.ReactNode;
+}
+
+interface TeamMemberProps {
+  name: string;
+  role: string;
+  bio: string;
+  image?: string;
+  socialLinks?: SocialLink[];
+}
+const TeamMember = ({ name, role, bio, image, socialLinks }: TeamMemberProps) => {
   return (
     <div className="bg-white rounded-lg overflow-hidden shadow-md hover:shadow-lg transition-all duration-300">
       <div className="h-64 bg-light-purple bg-opacity-10 relative">
@@ -37,7 +50,9 @@ const TeamMember = ({ name, role, bio, image, socialLinks }) => {
   );
 };
 
-const Team = () => {
+interface TeamProps {}
+
+const Team = ({}: TeamProps) => {
   const teamMembers = [
     {
       id: 1,

--- a/src/components/Technologies.tsx
+++ b/src/components/Technologies.tsx
@@ -1,7 +1,10 @@
 // components/Technologies.jsx
 import React from 'react';
 
-const TechnologyItem = ({ name }) => {
+interface TechnologyItemProps {
+  name: string;
+}
+const TechnologyItem = ({ name }: TechnologyItemProps) => {
   return (
     <div className="bg-white rounded-lg shadow-sm p-4 flex items-center justify-center hover:shadow-md transition-all duration-300 border border-light-purple border-opacity-20">
       <span className="text-dark-gray font-medium font-inter">{name}</span>
@@ -9,7 +12,12 @@ const TechnologyItem = ({ name }) => {
   );
 };
 
-const TechnologyCategory = ({ title, technologies }) => {
+interface TechnologyCategoryProps {
+  title: string;
+  technologies: string[];
+}
+
+const TechnologyCategory = ({ title, technologies }: TechnologyCategoryProps) => {
   return (
     <div className="mb-10">
       <h3 className="text-xl font-semibold mb-6 text-deep-blue font-montserrat">{title}</h3>
@@ -22,7 +30,9 @@ const TechnologyCategory = ({ title, technologies }) => {
   );
 };
 
-const Technologies = () => {
+interface TechnologiesProps {}
+
+const Technologies = ({}: TechnologiesProps) => {
   const frontendTechnologies = [
     "React", 
     "JavaScript", 


### PR DESCRIPTION
## Summary
- define explicit prop interfaces in each component file
- annotate component parameter types

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68782bd9167c8332a934c8b7e7f1a106