### PR TITLE
Add Head tags to pages

### DIFF
--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
+import Head from 'next/head';
 
 const AboutPage = () => {
   return (
-    <main className="pt-20">
+    <>
+      <Head>
+        <title>Phynnex Dev Studio - About</title>
+        <meta
+          name="description"
+          content="Learn more about Phynnex Dev Studio and our mission."
+        />
+      </Head>
+      <main className="pt-20">
       <div className="bg-whisper py-16">
         <div className="container mx-auto max-w-7xl px-4">
           <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">About Us</h1>
@@ -12,6 +21,7 @@ const AboutPage = () => {
         </div>
       </div>
     </main>
+    </>
   );
 };
 

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
+import Head from 'next/head';
 import Contact from '../components/Contact';
 
 const ContactPage = () => {
   return (
-    <main className="pt-20">
+    <>
+      <Head>
+        <title>Phynnex Dev Studio - Contact</title>
+        <meta
+          name="description"
+          content="Get in touch with Phynnex Dev Studio to discuss your project."
+        />
+      </Head>
+      <main className="pt-20">
       <div className="bg-whisper py-16">
         <div className="container mx-auto max-w-7xl px-4">
           <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Contact Us</h1>
@@ -14,6 +23,7 @@ const ContactPage = () => {
       </div>
       <Contact />
     </main>
+    </>
   );
 };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Head from "next/head";
 import Hero from "../components/Hero";
 import Services from "../components/Services";
 import Process from "../components/Process";
@@ -12,8 +13,16 @@ import Faq from "../components/FAQ";
 
 const HomePage = () => {
   return (
-    <main>
-      <Hero />
+    <>
+      <Head>
+        <title>Phynnex Dev Studio - Home</title>
+        <meta
+          name="description"
+          content="Welcome to Phynnex Dev Studio, your partner for custom digital solutions."
+        />
+      </Head>
+      <main>
+        <Hero />
       <Services />
       <Process />
       <Technologies />
@@ -22,8 +31,9 @@ const HomePage = () => {
       <Team/>
       <Faq />
       <CTA />
-      <Contact />
-    </main>
+        <Contact />
+      </main>
+    </>
   );
 };
 

--- a/src/pages/join.tsx
+++ b/src/pages/join.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
+import Head from 'next/head';
 
 const JoinPage = () => {
   return (
-    <main className="pt-20">
+    <>
+      <Head>
+        <title>Phynnex Dev Studio - Join</title>
+        <meta
+          name="description"
+          content="Join Phynnex Dev Studio to receive the latest updates and opportunities."
+        />
+      </Head>
+      <main className="pt-20">
       <div className="bg-whisper py-16">
         <div className="container mx-auto max-w-7xl px-4">
           <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Join Us</h1>
@@ -12,6 +21,7 @@ const JoinPage = () => {
         </div>
       </div>
     </main>
+    </>
   );
 };
 

--- a/src/pages/learn.tsx
+++ b/src/pages/learn.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
+import Head from 'next/head';
 
 const LearnPage = () => {
   return (
-    <main className="pt-20">
+    <>
+      <Head>
+        <title>Phynnex Dev Studio - Learn</title>
+        <meta
+          name="description"
+          content="Discover resources and articles from Phynnex Dev Studio."
+        />
+      </Head>
+      <main className="pt-20">
       <div className="bg-whisper py-16">
         <div className="container mx-auto max-w-7xl px-4">
           <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Learn</h1>
@@ -12,6 +21,7 @@ const LearnPage = () => {
         </div>
       </div>
     </main>
+    </>
   );
 };
 

--- a/src/pages/portfolio.tsx
+++ b/src/pages/portfolio.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
+import Head from 'next/head';
 import Portfolio from '../components/Portfolio';
 
 const PortfolioPage = () => {
   return (
-    <main className="pt-20">
+    <>
+      <Head>
+        <title>Phynnex Dev Studio - Portfolio</title>
+        <meta
+          name="description"
+          content="Explore successful projects delivered by Phynnex Dev Studio."
+        />
+      </Head>
+      <main className="pt-20">
       <div className="bg-whisper py-16">
         <div className="container mx-auto max-w-7xl px-4">
           <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Our Portfolio</h1>
@@ -14,6 +23,7 @@ const PortfolioPage = () => {
       </div>
       <Portfolio />
     </main>
+    </>
   );
 };
 

--- a/src/pages/process.tsx
+++ b/src/pages/process.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
+import Head from 'next/head';
 import Process from '../components/Process';
 
 const ProcessPage = () => {
   return (
-    <main className="pt-20">
+    <>
+      <Head>
+        <title>Phynnex Dev Studio - Process</title>
+        <meta
+          name="description"
+          content="Learn about the proven methodology we use at Phynnex Dev Studio."
+        />
+      </Head>
+      <main className="pt-20">
       <div className="bg-whisper py-16">
         <div className="container mx-auto max-w-7xl px-4">
           <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Our Process</h1>
@@ -14,6 +23,7 @@ const ProcessPage = () => {
       </div>
       <Process />
     </main>
+    </>
   );
 };
 

--- a/src/pages/services.tsx
+++ b/src/pages/services.tsx
@@ -1,10 +1,19 @@
 import React from 'react';
+import Head from 'next/head';
 import Services from '../components/Services';
 import CTA from '../components/CTA';
 
 const ServicesPage = () => {
   return (
-    <main className="pt-20">
+    <>
+      <Head>
+        <title>Phynnex Dev Studio - Services</title>
+        <meta
+          name="description"
+          content="Comprehensive digital solutions tailored to your business needs."
+        />
+      </Head>
+      <main className="pt-20">
       <div className="bg-whisper py-16">
         <div className="container mx-auto max-w-7xl px-4">
           <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Our Services</h1>
@@ -16,6 +25,7 @@ const ServicesPage = () => {
       <Services />
       <CTA />
     </main>
+    </>
   );
 };
 

--- a/src/pages/support.tsx
+++ b/src/pages/support.tsx
@@ -1,8 +1,17 @@
 import React from 'react';
+import Head from 'next/head';
 
 const SupportPage = () => {
   return (
-    <main className="pt-20">
+    <>
+      <Head>
+        <title>Phynnex Dev Studio - Support</title>
+        <meta
+          name="description"
+          content="Need help? Reach out to the Phynnex Dev Studio support center."
+        />
+      </Head>
+      <main className="pt-20">
       <div className="bg-whisper py-16">
         <div className="container mx-auto max-w-7xl px-4">
           <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Support Center</h1>
@@ -12,6 +21,7 @@ const SupportPage = () => {
         </div>
       </div>
     </main>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- add `<Head>` component to all pages for title and description

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68782c67eeac8332a1ca14b933e6fc23