### PR TITLE
Fix FAQ open item type

### DIFF
--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -41,7 +41,7 @@ const FAQItem = ({ question, answer, isOpen, toggleOpen }: FAQItemProps) => {
 interface FAQProps {}
 
 const FAQ = ({}: FAQProps) => {
-  const [openItem, setOpenItem] = useState(0);
+  const [openItem, setOpenItem] = useState<number | null>(null);
 
   const faqItems = [
     {
@@ -78,7 +78,7 @@ const FAQ = ({}: FAQProps) => {
     }
   ];
 
-  const toggleItem = (index) => {
+  const toggleItem = (index: number) => {
     setOpenItem(openItem === index ? null : index);
   };
 


### PR DESCRIPTION
## Summary
- fix openItem type in FAQ component
- update toggleItem to accept numeric index

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687830f1e758833281f16c9b5c327a4b