### PR TITLE
Add placeholder legal pages

### DIFF
--- a/src/pages/cookies.tsx
+++ b/src/pages/cookies.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Head from 'next/head';
+
+const CookiesPage = () => {
+  return (
+    <>
+      <Head>
+        <title>Phynnex Dev Studio - Cookies Settings</title>
+        <meta
+          name="description"
+          content="Information about how Phynnex Dev Studio uses cookies."
+        />
+      </Head>
+      <main className="pt-20">
+        <div className="bg-whisper py-16">
+          <div className="container mx-auto max-w-7xl px-4">
+            <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Cookies Settings</h1>
+            <p className="text-center text-lg text-gray-600 mt-4 max-w-3xl mx-auto">
+              This page is under construction.
+            </p>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default CookiesPage;

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Head from 'next/head';
+
+const PrivacyPage = () => {
+  return (
+    <>
+      <Head>
+        <title>Phynnex Dev Studio - Privacy Policy</title>
+        <meta
+          name="description"
+          content="Read about Phynnex Dev Studio's privacy practices."
+        />
+      </Head>
+      <main className="pt-20">
+        <div className="bg-whisper py-16">
+          <div className="container mx-auto max-w-7xl px-4">
+            <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Privacy Policy</h1>
+            <p className="text-center text-lg text-gray-600 mt-4 max-w-3xl mx-auto">
+              This page is under construction.
+            </p>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default PrivacyPage;

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Head from 'next/head';
+
+const TermsPage = () => {
+  return (
+    <>
+      <Head>
+        <title>Phynnex Dev Studio - Terms of Service</title>
+        <meta
+          name="description"
+          content="Understand the terms of service for using Phynnex Dev Studio."
+        />
+      </Head>
+      <main className="pt-20">
+        <div className="bg-whisper py-16">
+          <div className="container mx-auto max-w-7xl px-4">
+            <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Terms of Service</h1>
+            <p className="text-center text-lg text-gray-600 mt-4 max-w-3xl mx-auto">
+              This page is under construction.
+            </p>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default TermsPage;


### PR DESCRIPTION
## Summary
- add basic Privacy, Terms, and Cookies pages
- confirm footer links to these new pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878310c7cc88332be1f0f1c5f8df367