### PR TITLE
Convert config files to CommonJS

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,4 +3,4 @@ const nextConfig = {
   reactStrictMode: true,
 };
 
-export default nextConfig;
+module.exports = nextConfig;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 // tailwind.config.js
-export default {
+module.exports = {
   content: [
     './src/**/*.{js,ts,jsx,tsx}',
     './pages/**/*.{js,ts,jsx,tsx}'


### PR DESCRIPTION
## Summary
- convert `next.config.js` and `tailwind.config.js` to CommonJS syntax using `module.exports`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687831f043388332af11ef69c3b33c98