### PR TITLE
Fix PostCSS module export

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,7 @@
 // postcss.config.js
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
-  }
-}
+  },
+};


### PR DESCRIPTION
## Summary
- fix ESM warning by switching PostCSS config to CommonJS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6878360e14488332adf349a62fd2a984