### PR TITLE
Add Jest and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ npm run dev
 npm run lint
 ```
 
+4. Run tests
+
+```bash
+npm test
+```
+
 ## Building for production
 
 ```bash

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  dir: './',
+})
+
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  testEnvironment: 'jest-environment-jsdom',
+}
+
+module.exports = createJestConfig(customJestConfig)

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "next": "14.2.3",
@@ -22,6 +23,11 @@
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.3",
     "@types/react": "^18",
-    "@types/node": "^20"
+    "@types/node": "^20",
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/user-event": "^14.4.3",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }

--- a/src/components/__tests__/Hero.test.tsx
+++ b/src/components/__tests__/Hero.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react'
+import Hero from '../Hero'
+
+describe('Hero component', () => {
+  it('renders heading', () => {
+    render(<Hero />)
+    expect(screen.getByRole('heading', { name: /transform your ideas into powerful digital solutions/i })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add Jest configuration and testing utilities
- create a basic example test for the Hero component
- document how to run tests
- add a GitHub Actions workflow to run lint and test

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878389cd33c8332974a5beedea2ef3a