### PR TITLE
Fix textarea rows prop in Contact form

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -159,7 +159,7 @@ const Contact = ({}: ContactProps) => {
                 name="message"
                 value={formData.message}
                 onChange={handleChange}
-                rows="5"
+                rows={5}
                 className="w-full px-4 py-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-purple focus:border-transparent"
                 required
               ></textarea>


### PR DESCRIPTION
## Summary
- use JSX prop `rows={5}` instead of string in Contact textarea

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687839b9c48c83328de51859b60909e3