### PR TITLE
Add simple 404 page

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,32 +1,18 @@
-import React from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 
-const NotFoundPage = () => {
+export default function Custom404() {
   return (
     <>
       <Head>
-        <title>Phynnex Dev Studio - Page Not Found</title>
-        <meta
-          name="description"
-          content="The page you are looking for does not exist."
-        />
+        <title>Page Not Found</title>
       </Head>
-      <main className="pt-20">
-        <div className="bg-whisper py-16">
-          <div className="container mx-auto max-w-7xl px-4">
-            <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Page Not Found</h1>
-            <p className="text-center text-lg text-gray-600 mt-4 max-w-3xl mx-auto">
-              The page you are looking for doesn&apos;t exist.&nbsp;
-              <Link href="/" className="text-primary-purple underline">
-                Go back home
-              </Link>
-            </p>
-          </div>
-        </div>
+      <main className="min-h-screen flex flex-col items-center justify-center text-center">
+        <h1 className="text-2xl font-semibold mb-4">404 - Page Not Found</h1>
+        <Link href="/" className="text-primary-purple underline">
+          Return home
+        </Link>
       </main>
     </>
   );
-};
-
-export default NotFoundPage;
+}


### PR DESCRIPTION
## Summary
- simplify 404 page with direct message and link back to the homepage

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68783aaee0c48332b3d88a5831787646