### PR TITLE
Add nodemailer types to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@testing-library/react": "^14.1.2",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/user-event": "^14.4.3",
-    "jest-environment-jsdom": "^29.7.0"
+    "jest-environment-jsdom": "^29.7.0",
+    "@types/nodemailer": "^6.4.8"
   }
 }


### PR DESCRIPTION
## Summary
- add `@types/nodemailer` to development dependencies

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6878403e7b048332a54bdab4ff5a2e02