### PR TITLE
Refactor page structure and add layout wrapper

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,19 @@
+import React, { ReactNode } from 'react'
+import Navbar from './Navbar'
+import Footer from './Footer'
+
+interface LayoutProps {
+  children: ReactNode
+}
+
+const Layout = ({ children }: LayoutProps) => {
+  return (
+    <>
+      <Navbar />
+      <main className="pt-20">{children}</main>
+      <Footer />
+    </>
+  )
+}
+
+export default Layout

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,11 @@
 import type { AppProps } from 'next/app'
 import '../styles/globals.css'
+import Layout from '../components/Layout'
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  )
 }

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -11,7 +11,6 @@ const AboutPage = () => {
           content="Learn more about Phynnex Dev Studio and our mission."
         />
       </Head>
-      <main className="pt-20">
       <div className="bg-whisper py-16">
         <div className="container mx-auto max-w-7xl px-4">
           <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">About Us</h1>
@@ -20,7 +19,6 @@ const AboutPage = () => {
           </p>
         </div>
       </div>
-    </main>
     </>
   );
 };

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -12,7 +12,6 @@ const ContactPage = () => {
           content="Get in touch with Phynnex Dev Studio to discuss your project."
         />
       </Head>
-      <main className="pt-20">
       <div className="bg-whisper py-16">
         <div className="container mx-auto max-w-7xl px-4">
           <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Contact Us</h1>
@@ -22,7 +21,6 @@ const ContactPage = () => {
         </div>
       </div>
       <Contact />
-    </main>
     </>
   );
 };

--- a/src/pages/cookies.tsx
+++ b/src/pages/cookies.tsx
@@ -11,16 +11,14 @@ const CookiesPage = () => {
           content="Information about how Phynnex Dev Studio uses cookies."
         />
       </Head>
-      <main className="pt-20">
-        <div className="bg-whisper py-16">
-          <div className="container mx-auto max-w-7xl px-4">
-            <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Cookies Settings</h1>
-            <p className="text-center text-lg text-gray-600 mt-4 max-w-3xl mx-auto">
-              This page is under construction.
-            </p>
-          </div>
+      <div className="bg-whisper py-16">
+        <div className="container mx-auto max-w-7xl px-4">
+          <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Cookies Settings</h1>
+          <p className="text-center text-lg text-gray-600 mt-4 max-w-3xl mx-auto">
+            This page is under construction.
+          </p>
         </div>
-      </main>
+      </div>
     </>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Head from "next/head";
-import Navbar from "../components/Navbar";
 import Hero from "../components/Hero";
 import Services from "../components/Services";
 import Process from "../components/Process";
@@ -22,9 +21,7 @@ const HomePage = () => {
           content="Welcome to Phynnex Dev Studio, your partner for custom digital solutions."
         />
       </Head>
-      <main>
-        <Navbar/>
-        <Hero />
+      <Hero />
       <Services />
       <Process />
       <Technologies />
@@ -33,8 +30,7 @@ const HomePage = () => {
       <Team/>
       <Faq />
       <CTA />
-        <Contact />
-      </main>
+      <Contact />
     </>
   );
 };

--- a/src/pages/join.tsx
+++ b/src/pages/join.tsx
@@ -11,7 +11,6 @@ const JoinPage = () => {
           content="Join Phynnex Dev Studio to receive the latest updates and opportunities."
         />
       </Head>
-      <main className="pt-20">
       <div className="bg-whisper py-16">
         <div className="container mx-auto max-w-7xl px-4">
           <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Join Us</h1>
@@ -20,7 +19,6 @@ const JoinPage = () => {
           </p>
         </div>
       </div>
-    </main>
     </>
   );
 };

--- a/src/pages/learn.tsx
+++ b/src/pages/learn.tsx
@@ -11,7 +11,6 @@ const LearnPage = () => {
           content="Discover resources and articles from Phynnex Dev Studio."
         />
       </Head>
-      <main className="pt-20">
       <div className="bg-whisper py-16">
         <div className="container mx-auto max-w-7xl px-4">
           <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Learn</h1>
@@ -20,7 +19,6 @@ const LearnPage = () => {
           </p>
         </div>
       </div>
-    </main>
     </>
   );
 };

--- a/src/pages/portfolio.tsx
+++ b/src/pages/portfolio.tsx
@@ -12,7 +12,6 @@ const PortfolioPage = () => {
           content="Explore successful projects delivered by Phynnex Dev Studio."
         />
       </Head>
-      <main className="pt-20">
       <div className="bg-whisper py-16">
         <div className="container mx-auto max-w-7xl px-4">
           <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Our Portfolio</h1>
@@ -22,7 +21,6 @@ const PortfolioPage = () => {
         </div>
       </div>
       <Portfolio />
-    </main>
     </>
   );
 };

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -11,16 +11,14 @@ const PrivacyPage = () => {
           content="Read about Phynnex Dev Studio's privacy practices."
         />
       </Head>
-      <main className="pt-20">
-        <div className="bg-whisper py-16">
-          <div className="container mx-auto max-w-7xl px-4">
-            <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Privacy Policy</h1>
-            <p className="text-center text-lg text-gray-600 mt-4 max-w-3xl mx-auto">
-              This page is under construction.
-            </p>
-          </div>
+      <div className="bg-whisper py-16">
+        <div className="container mx-auto max-w-7xl px-4">
+          <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Privacy Policy</h1>
+          <p className="text-center text-lg text-gray-600 mt-4 max-w-3xl mx-auto">
+            This page is under construction.
+          </p>
         </div>
-      </main>
+      </div>
     </>
   );
 };

--- a/src/pages/process.tsx
+++ b/src/pages/process.tsx
@@ -12,7 +12,6 @@ const ProcessPage = () => {
           content="Learn about the proven methodology we use at Phynnex Dev Studio."
         />
       </Head>
-      <main className="pt-20">
       <div className="bg-whisper py-16">
         <div className="container mx-auto max-w-7xl px-4">
           <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Our Process</h1>
@@ -22,7 +21,6 @@ const ProcessPage = () => {
         </div>
       </div>
       <Process />
-    </main>
     </>
   );
 };

--- a/src/pages/services.tsx
+++ b/src/pages/services.tsx
@@ -13,7 +13,6 @@ const ServicesPage = () => {
           content="Comprehensive digital solutions tailored to your business needs."
         />
       </Head>
-      <main className="pt-20">
       <div className="bg-whisper py-16">
         <div className="container mx-auto max-w-7xl px-4">
           <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Our Services</h1>
@@ -24,7 +23,6 @@ const ServicesPage = () => {
       </div>
       <Services />
       <CTA />
-    </main>
     </>
   );
 };

--- a/src/pages/support.tsx
+++ b/src/pages/support.tsx
@@ -11,7 +11,6 @@ const SupportPage = () => {
           content="Need help? Reach out to the Phynnex Dev Studio support center."
         />
       </Head>
-      <main className="pt-20">
       <div className="bg-whisper py-16">
         <div className="container mx-auto max-w-7xl px-4">
           <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Support Center</h1>
@@ -20,7 +19,6 @@ const SupportPage = () => {
           </p>
         </div>
       </div>
-    </main>
     </>
   );
 };

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -11,16 +11,14 @@ const TermsPage = () => {
           content="Understand the terms of service for using Phynnex Dev Studio."
         />
       </Head>
-      <main className="pt-20">
-        <div className="bg-whisper py-16">
-          <div className="container mx-auto max-w-7xl px-4">
-            <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Terms of Service</h1>
-            <p className="text-center text-lg text-gray-600 mt-4 max-w-3xl mx-auto">
-              This page is under construction.
-            </p>
-          </div>
+      <div className="bg-whisper py-16">
+        <div className="container mx-auto max-w-7xl px-4">
+          <h1 className="text-4xl md:text-5xl font-bold text-center text-creole">Terms of Service</h1>
+          <p className="text-center text-lg text-gray-600 mt-4 max-w-3xl mx-auto">
+            This page is under construction.
+          </p>
         </div>
-      </main>
+      </div>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- add a simple Layout component containing `<main>` with padding
- wrap all pages using Layout in `_app.tsx`
- remove extra `<main>` tags and `pt-20` classes from individual pages

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d244215848332ba6da38123cefec3