### PR TITLE
Add component & API tests

### DIFF
--- a/src/components/__tests__/Contact.test.tsx
+++ b/src/components/__tests__/Contact.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Contact from '../Contact';
+
+describe('Contact component', () => {
+  it('renders heading', () => {
+    render(<Contact />);
+    expect(screen.getByRole('heading', { name: /get in touch/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/Process.test.tsx
+++ b/src/components/__tests__/Process.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Process from '../Process';
+
+describe('Process component', () => {
+  it('renders heading', () => {
+    render(<Process />);
+    expect(screen.getByRole('heading', { name: /our seamless development process explained/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/Services.test.tsx
+++ b/src/components/__tests__/Services.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Services from '../Services';
+
+describe('Services component', () => {
+  it('renders heading', () => {
+    render(<Services />);
+    expect(screen.getByRole('heading', { name: /expert digital solutions for your business/i })).toBeInTheDocument();
+  });
+});

--- a/src/pages/api/__tests__/contact.test.ts
+++ b/src/pages/api/__tests__/contact.test.ts
@@ -1,0 +1,43 @@
+import handler from '../contact';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import nodemailer from 'nodemailer';
+
+jest.mock('nodemailer');
+
+function createMocks(method: string, body: any = {}): { req: Partial<NextApiRequest>; res: any } {
+  const req = { method, body } as Partial<NextApiRequest>;
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    setHeader: jest.fn(),
+    end: jest.fn(),
+  } as any;
+  return { req, res };
+}
+
+describe('contact api route', () => {
+  it('rejects non-POST methods', async () => {
+    const { req, res } = createMocks('GET');
+    await handler(req as NextApiRequest, res as NextApiResponse);
+    expect(res.status).toHaveBeenCalledWith(405);
+    expect(res.end).toHaveBeenCalled();
+  });
+
+  it('validates required fields', async () => {
+    const { req, res } = createMocks('POST', {});
+    await handler(req as NextApiRequest, res as NextApiResponse);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ success: false, error: 'Missing fields' });
+  });
+
+  it('handles sendMail errors', async () => {
+    const sendMail = jest.fn().mockRejectedValue(new Error('fail'));
+    (nodemailer.createTransport as jest.Mock).mockReturnValue({ sendMail });
+
+    const { req, res } = createMocks('POST', { name: 'a', email: 'b', message: 'c' });
+    await handler(req as NextApiRequest, res as NextApiResponse);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ success: false, error: 'Failed to send email' });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for Contact, Services and Process components
- cover API contact endpoint validation and error handling

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68851afe5ae08332af0f0e4ed15d91c6