### PR TITLE
feat: add layered dark background utilities

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head />
+      <body className="bg-radial-deep bg-noise bg-grid-vignette">
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -9,8 +9,9 @@
 /* Base styles */
 body {
 
-  @apply font-inter antialiased text-off-white bg-black;
-
+  @apply font-inter antialiased text-off-white;
+  background-color: #0b0b12;
+  isolation: isolate;
 
 }
 
@@ -50,5 +51,49 @@ body {
 
   .container-custom {
     @apply container mx-auto max-w-7xl px-6 sm:px-8 lg:px-12;
+  }
+
+  .surface {
+    @apply bg-white/5 border border-white/10 rounded-2xl;
+    backdrop-filter: blur(4px);
+  }
+}
+
+@layer utilities {
+  .bg-radial-deep::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    background:
+      radial-gradient(60rem 40rem at 12% -10%, rgba(139,92,246,.18), transparent 60%),
+      radial-gradient(50rem 32rem at 88% 0%, rgba(236,72,153,.12), transparent 55%),
+      radial-gradient(90rem 60rem at 50% 110%, rgba(0,0,0,.6), transparent 70%);
+    pointer-events: none;
+  }
+
+  .bg-noise::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    opacity: .05;
+    pointer-events: none;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='300' height='300'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='.8' numOctaves='4' stitchTiles='stitch'/></filter><rect width='100%' height='100%' filter='url(#n)' opacity='.9'/></svg>");
+    background-size: 300px 300px;
+    mix-blend-mode: soft-light;
+  }
+
+  .bg-grid-vignette::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    background-image:
+      linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px);
+    background-size: 40px 40px;
+    -webkit-mask-image: radial-gradient(70% 55% at 50% 35%, black 60%, transparent 100%);
+            mask-image: radial-gradient(70% 55% at 50% 35%, black 60%, transparent 100%);
   }
 }


### PR DESCRIPTION
## Summary
- add radial-gradient, noise and grid utilities for richer dark backgrounds
- add `surface` component and apply layered background classes globally

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68990a14c43c833284066f581a3a03ea