### PR TITLE
refactor: load fonts with next/font

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,25 @@
 import type { AppProps } from 'next/app';
 import '../styles/globals.css';
 import Layout from '../components/Layout';
+import { Inter, Montserrat } from 'next/font/google';
+
+const inter = Inter({
+  subsets: ['latin'],
+  weight: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
+  variable: '--font-inter',
+});
+const montserrat = Montserrat({
+  subsets: ['latin'],
+  weight: ['100', '200', '300', '400', '500', '600', '700', '800', '900'],
+  variable: '--font-montserrat',
+});
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <Layout>
-      <Component {...pageProps} />
-    </Layout>
+    <div className={`${inter.variable} ${montserrat.variable} font-inter`}>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </div>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,6 +1,4 @@
 /* src/index.css */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@100;200;300;400;500;600;700;800;900&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -9,7 +7,7 @@
 /* Base styles */
 body {
 
-  @apply font-inter antialiased text-off-white;
+  @apply antialiased text-off-white;
   background-color: white;
 
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,8 +20,8 @@ module.exports = {
        
       },
       fontFamily: {
-        inter: ['Inter', 'sans-serif'],
-        montserrat: ['Montserrat', 'sans-serif'],
+        inter: ['var(--font-inter)', 'sans-serif'],
+        montserrat: ['var(--font-montserrat)', 'sans-serif'],
       },
       keyframes: {
         'fade-in-up': {


### PR DESCRIPTION
## Summary
- remove Google Fonts @import from global CSS
- load Inter and Montserrat via `next/font/google` and wire them through Tailwind variables

## Testing
- `npm test` *(fails: Unable to find accessible element... and NextRouter not mounted)*
- `npm run lint` *(fails: no-unescaped-entities, no-unused-vars, etc.)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689b5c69f5908332aa9842c7db062d0b