### PR TITLE
refactor: use next/image for hero background

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import Link from 'next/link';
-import type { StaticImageData } from 'next/image';
+import Image from 'next/image';
 import heroBg from '../assets/images/hero_bg.png';
 
 const Hero = () => {
@@ -31,11 +31,15 @@ const Hero = () => {
   return (
     <section className="relative w-full min-h-screen overflow-hidden pb-12 pt-28">
       {/* Background */}
-      <div
-        ref={bgRef}
-        className="absolute inset-0 bg-cover bg-center bg-no-repeat parallax -z-10"
-        style={{ backgroundImage: `url(${(heroBg as StaticImageData).src})` }}
-      />
+      <div ref={bgRef} className="absolute inset-0 parallax -z-10">
+        <Image
+          src={heroBg}
+          alt=""
+          aria-hidden="true"
+          fill
+          className="object-cover"
+        />
+      </div>
       {/* Gradient */}
       <div
         ref={gradRef}

--- a/src/components/__tests__/Hero.test.tsx
+++ b/src/components/__tests__/Hero.test.tsx
@@ -5,7 +5,7 @@ describe('Hero component', () => {
   it('renders heading', () => {
     render(<Hero />);
     expect(
-      screen.getByRole('heading', { name: /transform your ideas into powerful digital solutions/i })
+      screen.getByRole('heading', { name: /from vision to impact we build what's next/i })
     ).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/Navbar.test.tsx
+++ b/src/components/__tests__/Navbar.test.tsx
@@ -1,9 +1,24 @@
 import { render, screen } from '@testing-library/react';
+
+jest.mock('next/router', () => ({
+  useRouter() {
+    return {
+      pathname: '/',
+      events: {
+        on: jest.fn(),
+        off: jest.fn(),
+      },
+    };
+  },
+}));
+
 import Navbar from '../Navbar';
 
 describe('Navbar component', () => {
   it('renders navigation links', () => {
     render(<Navbar />);
-    expect(screen.getByRole('link', { name: /home page/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /phynnex dev studio logo/i })
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/Team.test.tsx
+++ b/src/components/__tests__/Team.test.tsx
@@ -4,6 +4,8 @@ import Team from '../Team';
 describe('Team component', () => {
   it('renders section heading', () => {
     render(<Team />);
-    expect(screen.getByText(/meet the experts behind phynnex/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /meet the brilliant minds behind innovation/i })
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- replace CSS background in Hero with absolutely positioned next/image
- mark hero background image decorative with alt and aria-hidden
- adjust component tests and mock next/router for Navbar

## Testing
- `npm test`
- `npm run lint` *(fails: react/no-unescaped-entities in FAQ.tsx, etc.)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689b5c81c5408332880cf2af3c0ea06b