### PR TITLE
fix: escape apostrophe in benefits text

### DIFF
--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -60,7 +60,7 @@ const Benefits = ({}: BenefitsProps) => {
               </h2>
 
               <p className="text-gray-300 font-inter text-lg lg:text-xl leading-relaxed mb-8 animate-fade-in-up opacity-90" style={{ animationDelay: '0.3s' }}>
-                When you choose our agency, you're gaining a strategic partner committed to delivering exceptional results that exceed expectations.
+                When you choose our agency, you&apos;re gaining a strategic partner committed to delivering exceptional results that exceed expectations.
               </p>
             </div>
 


### PR DESCRIPTION
## Summary
- escape apostrophe in Benefits component text to satisfy eslint

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'x-forwarded-for'))*
- `npm run lint` *(fails: 13 problems (10 errors, 3 warnings))*


------
https://chatgpt.com/codex/tasks/task_e_689b744a820c833292a2031682571252