### PR TITLE
Remove deprecated Amplify hosting adapter

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,26 +1,15 @@
-// /** @type {import('next').NextConfig} */
-// const nextConfig = {
-//   reactStrictMode: true,
-//   images: {
-//     remotePatterns: [
-//       {
-//         protocol: 'https',
-//         hostname: 'picsum.photos',
-//         pathname: '/**',
-//       },
-//     ],
-//   },
-// };
-
-// module.exports = nextConfig;
-
-// next.config.mjs
-import { withAmplifyHosting } from '@aws-amplify/adapter-nextjs';
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  swcMinify: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'picsum.photos',
+        pathname: '/**',
+      },
+    ],
+  },
 };
 
-export default withAmplifyHosting(nextConfig);
+export default nextConfig;


### PR DESCRIPTION
## Summary
- remove withAmplifyHosting from Next.js config as adapter no longer exports it
- allow remote images from picsum.photos

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cf7c0ecc4833286b0e31fca4a0fd7